### PR TITLE
Tkurth/mp fixes

### DIFF
--- a/distributed/helpers.py
+++ b/distributed/helpers.py
@@ -142,8 +142,8 @@ def _reduce_scatter(input_, dim_, comm_name):
     comm_rank = comm.get_rank(comm_name)
     input_ = input_.contiguous()
 
-    # Split along  dimension.
-    input_list = split_tensor_along_dim(input_, dim_, comm_size)
+    # Split along  dimension. Make sure the individual tensors are contiguous!
+    input_list = [t.contiguous() for t in split_tensor_along_dim(input_, dim_, comm_size)]
 
     output = torch.empty_like(input_list[comm_rank].contiguous())
     dist.reduce_scatter(output, input_list, group=comm.get_group(comm_name))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+ARG DLFW_VERSION
+FROM nvcr.io/nvidia/pytorch:${DLFW_VERSION}-py3
+
+RUN pip install parameterized
+
+ENV SCDLTUT_VERSION=0.1
+RUN cd /opt && git clone -b tkurth/mp-fixes https://github.com/azrael417/sc24-dl-tutorial.git
+ENV PYTHONPATH=${PYTHONPATH}:/opt/sc24-dl-tutorial
+
+#COPY distributed/layers.py /opt/sc24-dl-tutorial/distributed/layers.py
+#COPY networks/vit.py /opt/sc24-dl-tutorial/networks/vit.py
+#COPY distributed/helpers.py /opt/sc24-dl-tutorial/distributed/helpers.py

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# which version to take:
+dlfw_version=24.10
+
+# gitlab credentials
+gitlab_tag=latest
+
+cd ../
+
+# build and push
+docker build --network host -t sc24-dl-tutorial:${gitlab_tag} \
+       --build-arg DLFW_VERSION=${dlfw_version} \
+       -f docker/Dockerfile .

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -219,8 +219,11 @@ class TestDistributed(unittest.TestCase):
 
     # tests to run with input parameterization
     # inputs are batch, seq, embed, num_heads, tolerance
-    #@parameterized.expand([[4, 1024, 2048, 8, 1e-4], [4, 4096, 2048, 8, 1e-4], [4, 4050, 2048, 8, 1e-4]])
-    @parameterized.expand([[4, 4050, 2048, 8, 1e-4]])
+    @parameterized.expand([
+        [4, 1024, 2048, 8, 1e-4],
+        [4, 4096, 2048, 8, 1e-4],
+        [4, 4050, 2048, 8, 1e-4],
+    ])
     def test_distributed_attention(self, batch, seq, embed, num_heads, tolerance):
         # set the ops
         attn_layer = Attention(dim=embed, num_heads=num_heads, qkv_bias=True).to(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -223,6 +223,7 @@ class TestDistributed(unittest.TestCase):
         [4, 1024, 2048, 8, 1e-4],
         [4, 4096, 2048, 8, 1e-4],
         [4, 4050, 2048, 8, 1e-4],
+        [4, 4050, 2048, 1, 1e-4],
     ])
     def test_distributed_attention(self, batch, seq, embed, num_heads, tolerance):
         # set the ops

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -219,7 +219,8 @@ class TestDistributed(unittest.TestCase):
 
     # tests to run with input parameterization
     # inputs are batch, seq, embed, num_heads, tolerance
-    @parameterized.expand([[4, 1024, 2048, 8, 1e-4], [4, 4096, 2048, 8, 1e-4]])
+    #@parameterized.expand([[4, 1024, 2048, 8, 1e-4], [4, 4096, 2048, 8, 1e-4], [4, 4050, 2048, 8, 1e-4]])
+    @parameterized.expand([[4, 4050, 2048, 8, 1e-4]])
     def test_distributed_attention(self, batch, seq, embed, num_heads, tolerance):
         # set the ops
         attn_layer = Attention(dim=embed, num_heads=num_heads, qkv_bias=True).to(


### PR DESCRIPTION
This branch fixes a non-contiguous input tensor bug in reduce_scatter and also adds distributed tests for non power of two sequence lenghts in attention